### PR TITLE
bf/create-dir-if-not-exists

### DIFF
--- a/main.py
+++ b/main.py
@@ -157,9 +157,14 @@ class App:
             self.logs_folder = self.app_data.joinpath("logs")
             self.logs_folder.mkdir(parents=True, exist_ok=True)
             self.app_data.mkdir(parents=True, exist_ok=True)
+            
+            # Ensure ModCfgs folder exists
+            modcfgs_folder = APPDATA.joinpath("Trove/ModCfgs")
+            modcfgs_folder.mkdir(parents=True, exist_ok=True)  # Create if not exists
+            
             # Watch CFG edits
             asyncio.create_task(
-                self.monitor_directory(APPDATA.joinpath("Trove/ModCfgs"), self.loop)
+                self.monitor_directory(modcfgs_folder, self.loop)
             )
 
     async def load_configurations(self):


### PR DESCRIPTION
fixed bug where it was looking for a file that may not exist

```txt
Traceback (most recent call last):
  File "/home/extreme4all/dev/extreme4all/RenewedTroveTools/main.py", line 121, in monitor_directory
    observer.start()
  File "/home/extreme4all/dev/extreme4all/RenewedTroveTools/.venv/lib/python3.12/site-packages/watchdog/observers/api.py", line 265, in start
    emitter.start()
  File "/home/extreme4all/dev/extreme4all/RenewedTroveTools/.venv/lib/python3.12/site-packages/watchdog/utils/__init__.py", line 86, in start
    self.on_thread_start()
  File "/home/extreme4all/dev/extreme4all/RenewedTroveTools/.venv/lib/python3.12/site-packages/watchdog/observers/inotify.py", line 123, in on_thread_start
    self._inotify = InotifyBuffer(path, self.watch.is_recursive, event_mask)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/extreme4all/dev/extreme4all/RenewedTroveTools/.venv/lib/python3.12/site-packages/watchdog/observers/inotify_buffer.py", line 37, in __init__
    self._inotify = Inotify(path, recursive, event_mask)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/extreme4all/dev/extreme4all/RenewedTroveTools/.venv/lib/python3.12/site-packages/watchdog/observers/inotify_c.py", line 175, in __init__
    self._add_watch(path, event_mask)
  File "/home/extreme4all/dev/extreme4all/RenewedTroveTools/.venv/lib/python3.12/site-packages/watchdog/observers/inotify_c.py", line 387, in _add_watch
    Inotify._raise_error()
  File "/home/extreme4all/dev/extreme4all/RenewedTroveTools/.venv/lib/python3.12/site-packages/watchdog/observers/inotify_c.py", line 404, in _raise_error
    raise OSError(err, os.strerror(err))
FileNotFoundError: [Errno 2] No such file or directory
```